### PR TITLE
29 datasourcestore에서 k8sstore 분리

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1 h1:xvqufLtNVwAhN8NMyWklVgxnWohi+wtMGQMhtxexlm0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.7 h1:qcZcULcd/abmQg6dwigimCNEyi4gg31M/xaciQlDml8=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -27,14 +27,22 @@ func LoadStores(cfg *model.Config) (*Stores, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load alertrule configuration failed: %w", err)
 	}
-	datasourceStore, err := store.NewDatasourceStore(cfg.DatasourcesConfig)
-	if err != nil {
-		return nil, fmt.Errorf("load datasource configuration failed: %w", err)
-	}
 
 	userStore, err := store.NewUserStore("./data/venti.sqlite3", cfg.UserConfig)
 	if err != nil {
 		return nil, fmt.Errorf("load user configuration failed: %w", err)
+	}
+
+	var discoverer store.Discoverer
+	if cfg.DatasourcesConfig.Discovery.Enabled {
+		discoverer, err = store.NewK8sStore()
+		if err != nil {
+			return nil, fmt.Errorf("load discoverer k8sStore failed: %w", err)
+		}
+	}
+	datasourceStore, err := store.NewDatasourceStore(cfg.DatasourcesConfig, discoverer)
+	if err != nil {
+		return nil, fmt.Errorf("load datasource configuration failed: %w", err)
 	}
 
 	return &Stores{

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -2,6 +2,8 @@ package pkg
 
 import (
 	"fmt"
+	"github.com/kuoss/venti/pkg/store/discovery"
+	"github.com/kuoss/venti/pkg/store/discovery/kubernetes"
 
 	"github.com/gin-gonic/gin"
 	"github.com/kuoss/venti/pkg/handler"
@@ -33,9 +35,9 @@ func LoadStores(cfg *model.Config) (*Stores, error) {
 		return nil, fmt.Errorf("load user configuration failed: %w", err)
 	}
 
-	var discoverer store.Discoverer
+	var discoverer discovery.Discoverer
 	if cfg.DatasourcesConfig.Discovery.Enabled {
-		discoverer, err = store.NewK8sStore()
+		discoverer, err = kubernetes.NewK8sStore()
 		if err != nil {
 			return nil, fmt.Errorf("load discoverer k8sStore failed: %w", err)
 		}

--- a/pkg/store/datasource_store.go
+++ b/pkg/store/datasource_store.go
@@ -116,7 +116,7 @@ func (s *DatasourceStore) getDatasourcesFromServices(services []v1.Service) []co
 		}
 
 		// get port number of datasource from k8s service
-		portNumber := s.getPortNumberFromService(service)
+		portNumber := getPortNumberFromService(service)
 
 		// append to datasources
 		datasources = append(datasources, configuration.Datasource{
@@ -131,7 +131,7 @@ func (s *DatasourceStore) getDatasourcesFromServices(services []v1.Service) []co
 }
 
 // return port number within "http" named port. if not exist return service's first port number
-func (s *DatasourceStore) getPortNumberFromService(service v1.Service) int32 {
+func getPortNumberFromService(service v1.Service) int32 {
 
 	for _, port := range service.Spec.Ports {
 		if port.Name == "http" {

--- a/pkg/store/datasource_store.go
+++ b/pkg/store/datasource_store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"github.com/kuoss/venti/pkg/store/discovery"
 	"log"
 
 	"github.com/kuoss/venti/pkg/model"
@@ -11,11 +12,11 @@ import (
 type DatasourceStore struct {
 	config      *model.DatasourcesConfig
 	datasources []model.Datasource
-	discoverer  Discoverer
+	discoverer  discovery.Discoverer
 }
 
 // NewDatasourceStore return *DatasourceStore after service discovery (with k8s service)
-func NewDatasourceStore(cfg *model.DatasourcesConfig, discoverer Discoverer) (*DatasourceStore, error) {
+func NewDatasourceStore(cfg *model.DatasourcesConfig, discoverer discovery.Discoverer) (*DatasourceStore, error) {
 	store := &DatasourceStore{cfg, nil, discoverer}
 	err := store.load()
 	if err != nil {

--- a/pkg/store/datasource_store.go
+++ b/pkg/store/datasource_store.go
@@ -58,21 +58,13 @@ func (s *DatasourceStore) load() error {
 	return nil
 }
 
-func (s *DatasourceStore) discoverDatasources(clientset *kubernetes.Clientset) ([]configuration.Datasource, error) {
-	services, err := listServices(clientset)
-	if err != nil {
-		return nil, fmt.Errorf("error on listServices: %s", err)
-	}
-	return s.getDatasourcesFromServices(services), nil
-}
-
-func listServices(clientset *kubernetes.Clientset) ([]v1.Service, error) {
+func (s *DatasourceStore) discoverDatasources(clientset kubernetes.Interface) ([]configuration.Datasource, error) {
 
 	services, err := clientset.CoreV1().Services("").List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("cannot ListServices: %w", err)
 	}
-	return services.Items, nil
+	return s.getDatasourcesFromServices(services.Items), nil
 }
 
 // get datasources from k8s services

--- a/pkg/store/datasource_store.go
+++ b/pkg/store/datasource_store.go
@@ -39,9 +39,8 @@ func (s *DatasourceStore) load() error {
 		discoveredDatasources, err := s.discoverDatasources()
 		if err != nil {
 			log.Fatalf("error on discoverDatasources: %s", err)
-		} else {
-			s.datasources = append(s.datasources, discoveredDatasources...)
 		}
+		s.datasources = append(s.datasources, discoveredDatasources...)
 	}
 	// set main datasources
 	s.setMainDatasources()

--- a/pkg/store/datasource_store.go
+++ b/pkg/store/datasource_store.go
@@ -1,26 +1,22 @@
 package store
 
 import (
-	"context"
 	"fmt"
 	"log"
 
 	"github.com/kuoss/venti/pkg/model"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 // DatasourceStore
 type DatasourceStore struct {
 	config      *model.DatasourcesConfig
 	datasources []model.Datasource
+	discoverer  Discoverer
 }
 
 // NewDatasourceStore return *DatasourceStore after service discovery (with k8s service)
-func NewDatasourceStore(cfg *model.DatasourcesConfig) (*DatasourceStore, error) {
-	store := &DatasourceStore{cfg, nil}
+func NewDatasourceStore(cfg *model.DatasourcesConfig, discoverer Discoverer) (*DatasourceStore, error) {
+	store := &DatasourceStore{cfg, nil, discoverer}
 	err := store.load()
 	if err != nil {
 		return nil, fmt.Errorf("error on load: %w", err)
@@ -37,16 +33,7 @@ func (s *DatasourceStore) load() error {
 	// load from discovery
 	if s.config.Discovery.Enabled {
 
-		clusterCfg, err := rest.InClusterConfig()
-		if err != nil {
-			return fmt.Errorf("cannot InClusterConfig: %w", err)
-		}
-		clientset, err := kubernetes.NewForConfig(clusterCfg)
-		if err != nil {
-			return fmt.Errorf("cannot NewForConfig: %w", err)
-		}
-
-		discoveredDatasources, err := s.discoverDatasources(clientset)
+		discoveredDatasources, err := s.discoverer.Do(s.config.Discovery)
 		if err != nil {
 			log.Fatalf("error on discoverDatasources: %s", err)
 		}
@@ -58,90 +45,8 @@ func (s *DatasourceStore) load() error {
 	return nil
 }
 
-func (s *DatasourceStore) discoverDatasources(clientset kubernetes.Interface) ([]model.Datasource, error) {
-
-	services, err := clientset.CoreV1().Services("").List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("cannot ListServices: %w", err)
-	}
-	return s.getDatasourcesFromServices(services.Items), nil
-}
-
 // get datasources from k8s servicesWithoutAnnotation
 // recognize as a datasource by annotation or name
-func (s *DatasourceStore) getDatasourcesFromServices(services []v1.Service) []model.Datasource {
-	var datasources []model.Datasource
-
-	for _, service := range services {
-		datasourceType := getDatasourceTypeByConfig(service, s.config.Discovery)
-
-		// the service is not a datasource
-		if datasourceType == model.DatasourceTypeNone {
-			continue
-		}
-
-		// recognize as a main datasource by namespace
-		isMain := false
-		if service.Namespace == s.config.Discovery.MainNamespace {
-			isMain = true
-		}
-
-		// get port number of datasource from k8s service
-		portNumber := getPortNumberFromService(service)
-
-		// append to datasources
-		datasources = append(datasources, model.Datasource{
-			Name:         fmt.Sprintf("%s.%s", service.Name, service.Namespace),
-			Type:         datasourceType,
-			URL:          fmt.Sprintf("http://%s.%s:%d", service.Name, service.Namespace, portNumber),
-			IsDiscovered: true,
-			IsMain:       isMain,
-		})
-	}
-	return datasources
-}
-
-// getDatasourceTypeByConfig return DatasourceType.
-// 1. If configured within config.Discovery.ByNamePrometheus or config.Discovery.ByNameLethe return if service has matched name.
-// 2. If configured within config.Discovery.AnnotationKey matched with service's annotation key and also value is
-// one of promethe or lethe.
-func getDatasourceTypeByConfig(service v1.Service, cfg model.Discovery) model.DatasourceType {
-
-	// recognize as a datasource by name 'prometheus'
-	if cfg.ByNamePrometheus && service.Name == "prometheus" {
-		return model.DatasourceTypePrometheus
-	}
-	// recognize as a datasource by name 'lethe'
-	if cfg.ByNameLethe && service.Name == "lethe" {
-		return model.DatasourceTypeLethe
-	}
-
-	// recognize as a datasource by annotation of k8s service
-	for key, value := range service.Annotations {
-		if key != cfg.AnnotationKey {
-			continue
-		}
-		if value == string(model.DatasourceTypePrometheus) {
-			return model.DatasourceTypePrometheus
-		}
-		if value == string(model.DatasourceTypeLethe) {
-			return model.DatasourceTypeLethe
-		}
-	}
-
-	return model.DatasourceTypeNone
-}
-
-// return port number within "http" named port. if not exist return service's first port number
-func getPortNumberFromService(service v1.Service) int32 {
-
-	for _, port := range service.Spec.Ports {
-		if port.Name == "http" {
-			return port.Port
-		}
-	}
-	return service.Spec.Ports[0].Port
-}
 
 // ensure that there is one main datasource for each type
 func (s *DatasourceStore) setMainDatasources() {

--- a/pkg/store/datasource_store.go
+++ b/pkg/store/datasource_store.go
@@ -23,7 +23,7 @@ func NewDatasourceStore(cfg *configuration.DatasourcesConfig) (*DatasourceStore,
 	store := &DatasourceStore{cfg, nil}
 	err := store.load()
 	if err != nil {
-		return store, fmt.Errorf("error on load: %w", err)
+		return nil, fmt.Errorf("error on load: %w", err)
 	}
 	return store, nil
 }
@@ -51,7 +51,7 @@ func (s *DatasourceStore) load() error {
 func (s *DatasourceStore) discoverDatasources() ([]configuration.Datasource, error) {
 	services, err := listServices()
 	if err != nil {
-		return []configuration.Datasource{}, fmt.Errorf("error on listServices: %s", err)
+		return nil, fmt.Errorf("error on listServices: %s", err)
 	}
 	return s.getDatasourcesFromServices(services), nil
 }
@@ -59,16 +59,16 @@ func (s *DatasourceStore) discoverDatasources() ([]configuration.Datasource, err
 func listServices() ([]v1.Service, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		return []v1.Service{}, fmt.Errorf("cannot InClusterConfig: %w", err)
+		return nil, fmt.Errorf("cannot InClusterConfig: %w", err)
 	}
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return []v1.Service{}, fmt.Errorf("cannot NewForConfig: %w", err)
+		return nil, fmt.Errorf("cannot NewForConfig: %w", err)
 	}
 
 	services, err := clientset.CoreV1().Services("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return []v1.Service{}, fmt.Errorf("cannot ListServices: %w", err)
+		return nil, fmt.Errorf("cannot ListServices: %w", err)
 	}
 	return services.Items, nil
 }

--- a/pkg/store/datasource_store_test.go
+++ b/pkg/store/datasource_store_test.go
@@ -1,46 +1,13 @@
 package store
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/fake"
+	"github.com/kuoss/venti/pkg/store/discovery"
 	"testing"
 	"time"
 
 	"github.com/kuoss/venti/pkg/model"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func makeService(name string, namespace string, multiport bool, annotation map[string]string) runtime.Object {
-	ports := []v1.ServicePort{
-		{
-			Name:     "testport",
-			Protocol: v1.ProtocolTCP,
-			Port:     int32(30900),
-		},
-	}
-	if multiport {
-		ports = append(ports, v1.ServicePort{
-			Name:     "http",
-			Protocol: v1.ProtocolTCP,
-			Port:     int32(8080),
-		})
-	}
-
-	return runtime.Object(&v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Annotations: annotation,
-		},
-		Spec: v1.ServiceSpec{
-			Ports:     ports,
-			Type:      v1.ServiceTypeClusterIP,
-			ClusterIP: "10.0.0.1",
-		},
-	})
-}
 
 func TestNewDatasourceStore(t *testing.T) {
 	datasources := []model.Datasource{
@@ -60,151 +27,9 @@ func TestNewDatasourceStore(t *testing.T) {
 			ByNameLethe:      true,
 		},
 	}
-	var defaultDiscoverer Discoverer
+	var defaultDiscoverer discovery.Discoverer
 	store, err := NewDatasourceStore(datasourcesConfig, defaultDiscoverer)
 	assert.Nil(t, err)
 	assert.Equal(t, store.config, datasourcesConfig)
 	assert.ElementsMatch(t, store.datasources, datasources)
-}
-
-var servicesWithoutAnnotation = []runtime.Object{
-	makeService("prometheus", "namespace1", false, nil),
-	makeService("prometheus", "namespace2", false, nil),
-	makeService("prometheus", "kube-system", false, nil),
-	makeService("lethe", "kuoss", true, nil),
-	makeService("lethe", "kube-system", true, nil),
-}
-
-func TestDiscoverDatasourcesByName(t *testing.T) {
-	datasourcesConfig := &model.DatasourcesConfig{
-		QueryTimeout: time.Second * 10,
-		Datasources:  []*model.Datasource{},
-		Discovery: model.Discovery{
-			Enabled:          false,
-			ByNamePrometheus: true,
-			ByNameLethe:      true,
-		},
-	}
-	want := []model.Datasource{
-		{
-			Type:         "lethe",
-			Name:         "lethe.kube-system",
-			URL:          "http://lethe.kube-system:8080",
-			IsMain:       false,
-			IsDiscovered: true,
-		},
-		{
-			Type:         "prometheus",
-			Name:         "prometheus.kube-system",
-			URL:          "http://prometheus.kube-system:30900",
-			IsMain:       false,
-			IsDiscovered: true,
-		},
-		{
-			Type:         "lethe",
-			Name:         "lethe.kuoss",
-			URL:          "http://lethe.kuoss:8080",
-			IsMain:       false,
-			IsDiscovered: true,
-		},
-		{
-			Type:         "prometheus",
-			Name:         "prometheus.namespace1",
-			URL:          "http://prometheus.namespace1:30900",
-			IsMain:       false,
-			IsDiscovered: true,
-		},
-		{
-			Type:         "prometheus",
-			Name:         "prometheus.namespace2",
-			URL:          "http://prometheus.namespace2:30900",
-			IsMain:       false,
-			IsDiscovered: true,
-		}}
-
-	k8sStore := &k8sStore{fake.NewSimpleClientset(servicesWithoutAnnotation...)}
-
-	store, _ := NewDatasourceStore(datasourcesConfig, k8sStore)
-	got, err := store.discoverer.Do(datasourcesConfig.Discovery)
-	if err != nil {
-		return
-	}
-	assert.ElementsMatch(t, want, got)
-}
-
-var servicesWithAnnotation = []runtime.Object{
-	makeService("prometheus", "namespace1", false, map[string]string{
-		"kuoss.org/datasource-type": "prometheus",
-	}),
-	makeService("prometheus", "namespace2", false, map[string]string{
-		"kuoss.org/datasource-type": "prometheus",
-	}),
-	makeService("prometheus", "kube-system", false, map[string]string{
-		"kuoss.org/datasource-type": "prometheus",
-	}),
-	makeService("lethe", "kuoss", true, map[string]string{
-		"kuoss.org/datasource-type": "lethe",
-	}),
-	makeService("lethe", "kube-system", true, map[string]string{
-		"kuoss.org/datasource-type": "lethe",
-	}),
-}
-
-func TestDiscoverDatasourcesByAnnotationKey(t *testing.T) {
-	datasourcesConfig := &model.DatasourcesConfig{
-		QueryTimeout: time.Second * 10,
-		Datasources:  []*model.Datasource{},
-		Discovery: model.Discovery{
-			Enabled:          true,
-			AnnotationKey:    "kuoss.org/datasource-type",
-			ByNamePrometheus: false,
-			ByNameLethe:      false,
-		},
-	}
-	want := []model.Datasource{
-		{
-			Type:         "lethe",
-			Name:         "lethe.kube-system",
-			URL:          "http://lethe.kube-system:8080",
-			IsMain:       false,
-			IsDiscovered: true,
-		},
-		{
-			Type:         "prometheus",
-			Name:         "prometheus.kube-system",
-			URL:          "http://prometheus.kube-system:30900",
-			IsMain:       false,
-			IsDiscovered: true,
-		},
-		{
-			Type:         "lethe",
-			Name:         "lethe.kuoss",
-			URL:          "http://lethe.kuoss:8080",
-			IsMain:       false,
-			IsDiscovered: true,
-		},
-		{
-			Type:         "prometheus",
-			Name:         "prometheus.namespace1",
-			URL:          "http://prometheus.namespace1:30900",
-			IsMain:       false,
-			IsDiscovered: true,
-		},
-		{
-			Type:         "prometheus",
-			Name:         "prometheus.namespace2",
-			URL:          "http://prometheus.namespace2:30900",
-			IsMain:       false,
-			IsDiscovered: true,
-		}}
-
-	k8sStore := &k8sStore{fake.NewSimpleClientset(servicesWithAnnotation...)}
-
-	store, _ := NewDatasourceStore(datasourcesConfig, k8sStore)
-
-	got, err := store.discoverer.Do(datasourcesConfig.Discovery)
-	if err != nil {
-		return
-	}
-	assert.ElementsMatch(t, got, want)
 }

--- a/pkg/store/datasource_store_test.go
+++ b/pkg/store/datasource_store_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 	"testing"
 	"time"
 
@@ -10,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func makeService(name string, namespace string, multiport bool) v1.Service {
+func makeService(name string, namespace string, multiport bool, annotation map[string]string) runtime.Object {
 	ports := []v1.ServicePort{
 		{
 			Name:     "testport",
@@ -25,17 +27,19 @@ func makeService(name string, namespace string, multiport bool) v1.Service {
 			Port:     int32(8080),
 		})
 	}
-	return v1.Service{
+
+	return runtime.Object(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotation,
 		},
 		Spec: v1.ServiceSpec{
 			Ports:     ports,
 			Type:      v1.ServiceTypeClusterIP,
 			ClusterIP: "10.0.0.1",
 		},
-	}
+	})
 }
 
 func TestNewDatasourceStore(t *testing.T) {
@@ -62,7 +66,15 @@ func TestNewDatasourceStore(t *testing.T) {
 	assert.ElementsMatch(t, store.datasources, datasources)
 }
 
-func TestGetDatasourcesFromServices(t *testing.T) {
+var servicesWithoutAnnotation = []runtime.Object{
+	makeService("prometheus", "namespace1", false, nil),
+	makeService("prometheus", "namespace2", false, nil),
+	makeService("prometheus", "kube-system", false, nil),
+	makeService("lethe", "kuoss", true, nil),
+	makeService("lethe", "kube-system", true, nil),
+}
+
+func TestDiscoverDatasourcesByName(t *testing.T) {
 	datasourcesConfig := &configuration.DatasourcesConfig{
 		QueryTimeout: time.Second * 10,
 		Datasources:  []*configuration.Datasource{},
@@ -72,20 +84,119 @@ func TestGetDatasourcesFromServices(t *testing.T) {
 			ByNameLethe:      true,
 		},
 	}
+	want := []configuration.Datasource{
+		{
+			Type:         "lethe",
+			Name:         "lethe.kube-system",
+			URL:          "http://lethe.kube-system:8080",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "prometheus",
+			Name:         "prometheus.kube-system",
+			URL:          "http://prometheus.kube-system:30900",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "lethe",
+			Name:         "lethe.kuoss",
+			URL:          "http://lethe.kuoss:8080",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "prometheus",
+			Name:         "prometheus.namespace1",
+			URL:          "http://prometheus.namespace1:30900",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "prometheus",
+			Name:         "prometheus.namespace2",
+			URL:          "http://prometheus.namespace2:30900",
+			IsMain:       false,
+			IsDiscovered: true,
+		}}
 	store, _ := NewDatasourceStore(datasourcesConfig)
-	services := []v1.Service{
-		makeService("prometheus", "namespace1", false),
-		makeService("prometheus", "namespace2", false),
-		makeService("prometheus", "kube-system", false),
-		makeService("lethe", "kuoss", true),
-		makeService("lethe", "kube-system", true),
+	got, err := store.discoverDatasources(fake.NewSimpleClientset(servicesWithoutAnnotation...))
+	if err != nil {
+		return
 	}
-	got := store.getDatasourcesFromServices(services)
-	assert.ElementsMatch(t, []configuration.Datasource{
-		{Type: "prometheus", Name: "prometheus.namespace1", URL: "http://prometheus.namespace1:30900", BasicAuth: false, BasicAuthUser: "", BasicAuthPassword: "", IsMain: false, IsDiscovered: true},
-		{Type: "prometheus", Name: "prometheus.namespace2", URL: "http://prometheus.namespace2:30900", BasicAuth: false, BasicAuthUser: "", BasicAuthPassword: "", IsMain: false, IsDiscovered: true},
-		{Type: "prometheus", Name: "prometheus.kube-system", URL: "http://prometheus.kube-system:30900", BasicAuth: false, BasicAuthUser: "", BasicAuthPassword: "", IsMain: false, IsDiscovered: true},
-		{Type: "lethe", Name: "lethe.kuoss", URL: "http://lethe.kuoss:8080", BasicAuth: false, BasicAuthUser: "", BasicAuthPassword: "", IsMain: false, IsDiscovered: true},
-		{Type: "lethe", Name: "lethe.kube-system", URL: "http://lethe.kube-system:8080", BasicAuth: false, BasicAuthUser: "", BasicAuthPassword: "", IsMain: false, IsDiscovered: true},
-	}, got)
+	assert.ElementsMatch(t, want, got)
+}
+
+var servicesWithAnnotation = []runtime.Object{
+	makeService("prometheus", "namespace1", false, map[string]string{
+		"kuoss.org/datasource-type": "prometheus",
+	}),
+	makeService("prometheus", "namespace2", false, map[string]string{
+		"kuoss.org/datasource-type": "prometheus",
+	}),
+	makeService("prometheus", "kube-system", false, map[string]string{
+		"kuoss.org/datasource-type": "prometheus",
+	}),
+	makeService("lethe", "kuoss", true, map[string]string{
+		"kuoss.org/datasource-type": "lethe",
+	}),
+	makeService("lethe", "kube-system", true, map[string]string{
+		"kuoss.org/datasource-type": "lethe",
+	}),
+}
+
+func TestDiscoverDatasourcesByAnnotationKey(t *testing.T) {
+	datasourcesConfig := &configuration.DatasourcesConfig{
+		QueryTimeout: time.Second * 10,
+		Datasources:  []*configuration.Datasource{},
+		Discovery: configuration.Discovery{
+			Enabled:          false, // cheat
+			AnnotationKey:    "kuoss.org/datasource-type",
+			ByNamePrometheus: false,
+			ByNameLethe:      false,
+		},
+	}
+	want := []configuration.Datasource{
+		{
+			Type:         "lethe",
+			Name:         "lethe.kube-system",
+			URL:          "http://lethe.kube-system:8080",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "prometheus",
+			Name:         "prometheus.kube-system",
+			URL:          "http://prometheus.kube-system:30900",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "lethe",
+			Name:         "lethe.kuoss",
+			URL:          "http://lethe.kuoss:8080",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "prometheus",
+			Name:         "prometheus.namespace1",
+			URL:          "http://prometheus.namespace1:30900",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "prometheus",
+			Name:         "prometheus.namespace2",
+			URL:          "http://prometheus.namespace2:30900",
+			IsMain:       false,
+			IsDiscovered: true,
+		}}
+	store, _ := NewDatasourceStore(datasourcesConfig)
+	got, err := store.discoverDatasources(fake.NewSimpleClientset(servicesWithAnnotation...))
+	if err != nil {
+		return
+	}
+	assert.ElementsMatch(t, got, want)
 }

--- a/pkg/store/discovery/discovery.go
+++ b/pkg/store/discovery/discovery.go
@@ -1,0 +1,7 @@
+package discovery
+
+import "github.com/kuoss/venti/pkg/model"
+
+type Discoverer interface {
+	Do(discovery model.Discovery) ([]model.Datasource, error)
+}

--- a/pkg/store/discovery/kubernetes/kubernetes.go
+++ b/pkg/store/discovery/kubernetes/kubernetes.go
@@ -105,7 +105,7 @@ func getDatasourceTypeByConfig(service v1.Service, cfg model.Discovery) model.Da
 // return port number within "http" named port. if not exist return service's first port number
 func getPortNumberFromService(service v1.Service) (int32, error) {
 	if len(service.Spec.Ports) < 1 {
-		return 0, fmt.Errorf("service %s/%s have any port", service.Name, service.Namespace)
+		return 0, fmt.Errorf("service %s/%s have any port", service.Namespace, service.Name)
 	}
 
 	for _, port := range service.Spec.Ports {

--- a/pkg/store/discovery/kubernetes/kubernetes.go
+++ b/pkg/store/discovery/kubernetes/kubernetes.go
@@ -105,7 +105,7 @@ func getDatasourceTypeByConfig(service v1.Service, cfg model.Discovery) model.Da
 // return port number within "http" named port. if not exist return service's first port number
 func getPortNumberFromService(service v1.Service) (int32, error) {
 	if len(service.Spec.Ports) < 1 {
-		return 0, fmt.Errorf("service %v have any port", service)
+		return 0, fmt.Errorf("service %s/%s have any port", service.Name, service.Namespace)
 	}
 
 	for _, port := range service.Spec.Ports {

--- a/pkg/store/discovery/kubernetes/kubernetes_test.go
+++ b/pkg/store/discovery/kubernetes/kubernetes_test.go
@@ -1,0 +1,168 @@
+package kubernetes
+
+import (
+	"github.com/kuoss/venti/pkg/model"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+func makeService(name string, namespace string, multiport bool, annotation map[string]string) runtime.Object {
+	ports := []v1.ServicePort{
+		{
+			Name:     "testport",
+			Protocol: v1.ProtocolTCP,
+			Port:     int32(30900),
+		},
+	}
+	if multiport {
+		ports = append(ports, v1.ServicePort{
+			Name:     "http",
+			Protocol: v1.ProtocolTCP,
+			Port:     int32(8080),
+		})
+	}
+
+	return runtime.Object(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotation,
+		},
+		Spec: v1.ServiceSpec{
+			Ports:     ports,
+			Type:      v1.ServiceTypeClusterIP,
+			ClusterIP: "10.0.0.1",
+		},
+	})
+}
+
+var servicesWithoutAnnotation = []runtime.Object{
+	makeService("prometheus", "namespace1", false, nil),
+	makeService("prometheus", "namespace2", false, nil),
+	makeService("prometheus", "kube-system", false, nil),
+	makeService("lethe", "kuoss", true, nil),
+	makeService("lethe", "kube-system", true, nil),
+}
+
+var servicesWithAnnotation = []runtime.Object{
+	makeService("prometheus", "namespace1", false, map[string]string{
+		"kuoss.org/datasource-type": "prometheus",
+	}),
+	makeService("prometheus", "namespace2", false, map[string]string{
+		"kuoss.org/datasource-type": "prometheus",
+	}),
+	makeService("prometheus", "kube-system", false, map[string]string{
+		"kuoss.org/datasource-type": "prometheus",
+	}),
+	makeService("lethe", "kuoss", true, map[string]string{
+		"kuoss.org/datasource-type": "lethe",
+	}),
+	makeService("lethe", "kube-system", true, map[string]string{
+		"kuoss.org/datasource-type": "lethe",
+	}),
+}
+
+func TestDoDiscoveryWithoutAnnotationKey(t *testing.T) {
+	want := []model.Datasource{
+		{
+			Type:         "lethe",
+			Name:         "lethe.kube-system",
+			URL:          "http://lethe.kube-system:8080",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "prometheus",
+			Name:         "prometheus.kube-system",
+			URL:          "http://prometheus.kube-system:30900",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "lethe",
+			Name:         "lethe.kuoss",
+			URL:          "http://lethe.kuoss:8080",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "prometheus",
+			Name:         "prometheus.namespace1",
+			URL:          "http://prometheus.namespace1:30900",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "prometheus",
+			Name:         "prometheus.namespace2",
+			URL:          "http://prometheus.namespace2:30900",
+			IsMain:       false,
+			IsDiscovered: true,
+		}}
+
+	k8sStore := &k8sStore{fake.NewSimpleClientset(servicesWithoutAnnotation...)}
+	discovered, err := k8sStore.Do(model.Discovery{
+		Enabled:          true,
+		ByNamePrometheus: true,
+		ByNameLethe:      true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.ElementsMatch(t, want, discovered)
+}
+
+func TestDoDiscoveryAnnotationKey(t *testing.T) {
+	want := []model.Datasource{
+		{
+			Type:         "lethe",
+			Name:         "lethe.kube-system",
+			URL:          "http://lethe.kube-system:8080",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "prometheus",
+			Name:         "prometheus.kube-system",
+			URL:          "http://prometheus.kube-system:30900",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "lethe",
+			Name:         "lethe.kuoss",
+			URL:          "http://lethe.kuoss:8080",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "prometheus",
+			Name:         "prometheus.namespace1",
+			URL:          "http://prometheus.namespace1:30900",
+			IsMain:       false,
+			IsDiscovered: true,
+		},
+		{
+			Type:         "prometheus",
+			Name:         "prometheus.namespace2",
+			URL:          "http://prometheus.namespace2:30900",
+			IsMain:       false,
+			IsDiscovered: true,
+		}}
+
+	k8sStore := &k8sStore{fake.NewSimpleClientset(servicesWithAnnotation...)}
+	discovered, err := k8sStore.Do(model.Discovery{
+		Enabled:          true,
+		AnnotationKey:    "kuoss.org/datasource-type",
+		ByNamePrometheus: false,
+		ByNameLethe:      false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.ElementsMatch(t, want, discovered)
+}

--- a/pkg/store/k8sStore.go
+++ b/pkg/store/k8sStore.go
@@ -1,0 +1,114 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"github.com/kuoss/venti/pkg/model"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type Discoverer interface {
+	Do(discovery model.Discovery) ([]model.Datasource, error)
+}
+
+type k8sStore struct {
+	client kubernetes.Interface
+}
+
+func NewK8sStore() (*k8sStore, error) {
+	clusterCfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("cannot InClusterConfig: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(clusterCfg)
+	if err != nil {
+		return nil, fmt.Errorf("cannot NewForConfig: %w", err)
+	}
+	return &k8sStore{client: clientset}, nil
+}
+
+func (s *k8sStore) Do(discovery model.Discovery) ([]model.Datasource, error) {
+
+	services, err := s.client.CoreV1().Services("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("cannot ListServices: %w", err)
+	}
+	return s.getDatasourcesFromServices(services.Items, discovery), nil
+}
+
+func (s *k8sStore) getDatasourcesFromServices(services []v1.Service, discovery model.Discovery) []model.Datasource {
+	var datasources []model.Datasource
+
+	for _, service := range services {
+		datasourceType := getDatasourceTypeByConfig(service, discovery)
+
+		// the service is not a datasource
+		if datasourceType == model.DatasourceTypeNone {
+			continue
+		}
+
+		// recognize as a main datasource by namespace
+		isMain := false
+		if service.Namespace == discovery.MainNamespace {
+			isMain = true
+		}
+
+		// get port number of datasource from k8s service
+		portNumber := getPortNumberFromService(service)
+
+		// append to datasources
+		datasources = append(datasources, model.Datasource{
+			Name:         fmt.Sprintf("%s.%s", service.Name, service.Namespace),
+			Type:         datasourceType,
+			URL:          fmt.Sprintf("http://%s.%s:%d", service.Name, service.Namespace, portNumber),
+			IsDiscovered: true,
+			IsMain:       isMain,
+		})
+	}
+	return datasources
+}
+
+// getDatasourceTypeByConfig return DatasourceType.
+// 1. If configured within config.Discovery.ByNamePrometheus or config.Discovery.ByNameLethe return if service has matched name.
+// 2. If configured within config.Discovery.AnnotationKey matched with service's annotation key and also value is
+// one of promethe or lethe.
+func getDatasourceTypeByConfig(service v1.Service, cfg model.Discovery) model.DatasourceType {
+
+	// recognize as a datasource by name 'prometheus'
+	if cfg.ByNamePrometheus && service.Name == "prometheus" {
+		return model.DatasourceTypePrometheus
+	}
+	// recognize as a datasource by name 'lethe'
+	if cfg.ByNameLethe && service.Name == "lethe" {
+		return model.DatasourceTypeLethe
+	}
+
+	// recognize as a datasource by annotation of k8s service
+	for key, value := range service.Annotations {
+		if key != cfg.AnnotationKey {
+			continue
+		}
+		if value == string(model.DatasourceTypePrometheus) {
+			return model.DatasourceTypePrometheus
+		}
+		if value == string(model.DatasourceTypeLethe) {
+			return model.DatasourceTypeLethe
+		}
+	}
+
+	return model.DatasourceTypeNone
+}
+
+// return port number within "http" named port. if not exist return service's first port number
+func getPortNumberFromService(service v1.Service) int32 {
+
+	for _, port := range service.Spec.Ports {
+		if port.Name == "http" {
+			return port.Port
+		}
+	}
+	return service.Spec.Ports[0].Port
+}


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

1. k8s client 역할이 필요한 곳이 datasource를 discovery 하는 곳 말고는 따로 쓰일 가능성이 낮을 것 같아 따로 타입으로 작성하지는 않았습니다.
2.  discovery과정 중 `getDatasourcesFromServices` 부분을 간소화 했습니다.
3. k8s clientSet을 테스트하기 위해서 `fake.NewSimpleClientset()`를 사용했습니다. 아래 코드처럼 미리 object를 생성한 뒤 fakeNewSimpleClientset()의 파라미터로 전달해서 clientSet을 생성하면, clientSet은 전달한 파라미터를 리턴합니다.
```go
service := makeService("prometheus", "namespace1", false, nil),
clientSet := fake.NewSimpleClientset(service)
services, err := clientset.CoreV1().Services("").List(context.Background(), metav1.ListOptions{})
```
4. 그래서 Service 오브젝트에 annotation이 있는 경우, ByName으로 discovery되는 경우의 테스트 코드를 추가했습니다.
5.`TestDiscoverDatasourcesByAnnotationKey` 테스트의 경우 Discovery.Enable = false로 되어있는 cheat가 있습니다.

#### Which issue(s) this PR fixes (관련 이슈):
#29 


#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):
k8s client 사용이 discovery 말고 쓰일 곳이 있을까요? 개인적으로는 다른 용도로 쓰이는 것이 생각나지 않았습니다.


#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

