### PR TITLE
Two depth dashboard files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN cd web && npm install --force
 RUN cd web && npm run build
 RUN mkdir -p             /app/web/
 RUN cp -a /temp/web/dist /app/web/
+RUN mkdir -p             /app/data/ ## for user sqlite file
 
 FROM alpine:3.18
 COPY --from=base2 /app /app

--- a/pkg/model/dashboard.go
+++ b/pkg/model/dashboard.go
@@ -22,16 +22,17 @@ type ChartOptions struct {
 	YMax int `json:"yMax,omitempty" yaml:"yMax,omitempty"`
 }
 
-// todo: what Legend, Legends is for?
+// TODO: what Legend, Legends is for?
 type Target struct {
-	Expr       string      `json:"expr"`
-	Legend     string      `json:"legend,omitempty" yaml:"legend,omitempty"`
-	Legends    []string    `json:"legends,omitempty" yaml:"legends,omitempty"`
-	Unit       string      `json:"unit,omitempty" yaml:"unit,omitempty"`
-	Columns    []string    `json:"columns,omitempty" yaml:"columns,omitempty"`
-	Headers    []string    `json:"headers,omitempty" yaml:"headers,omitempty"`
-	Key        string      `json:"key,omitempty" yaml:"key,omitempty"`
-	Thresholds []Threshold `json:"thresholds,omitempty" yaml:"thresholds,omitempty"`
+	Expr        string      `json:"expr"`
+	Legend      string      `json:"legend,omitempty" yaml:"legend,omitempty"`
+	Legends     []string    `json:"legends,omitempty" yaml:"legends,omitempty"`
+	Unit        string      `json:"unit,omitempty" yaml:"unit,omitempty"`
+	Columns     []string    `json:"columns,omitempty" yaml:"columns,omitempty"`
+	Headers     []string    `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Key         string      `json:"key,omitempty" yaml:"key,omitempty"`
+	Thresholds  []Threshold `json:"thresholds,omitempty" yaml:"thresholds,omitempty"`
+	Aggregation string      `json:"aggregation,omitempty" yaml:"aggregation,omitempty"`
 }
 
 type Threshold struct {

--- a/pkg/store/dashboard/dashboard.go
+++ b/pkg/store/dashboard/dashboard.go
@@ -14,18 +14,32 @@ type DashboardStore struct {
 	dashboards []model.Dashboard
 }
 
-func New(pattern string) (*DashboardStore, error) {
-	logger.Debugf("NewDashboardStore...")
-	if pattern == "" {
-		pattern = "etc/dashboards/*.yml"
+func getDashboardFilesFromPath(dirpath string) ([]string, error) {
+	if dirpath == "" {
+		dirpath = "etc/dashboards"
 	}
-	files, err := filepath.Glob(pattern)
+	files, err := filepath.Glob(dirpath + "/*.y*ml")
 	if err != nil {
 		return nil, fmt.Errorf("glob err: %w", err)
 	}
-	if len(files) < 1 {
-		return nil, fmt.Errorf("no dashboard file: pattern: %s", pattern)
+	files2, err := filepath.Glob(dirpath + "/*/*.y*ml")
+	if err != nil {
+		return nil, fmt.Errorf("glob err: %w", err)
 	}
+	files = append(files, files2...)
+	if len(files) < 1 {
+		return nil, fmt.Errorf("no dashboard file: dirpath: %s", dirpath)
+	}
+	return files, nil
+}
+
+func New(dirpath string) (*DashboardStore, error) {
+	logger.Debugf("NewDashboardStore...")
+	files, err := getDashboardFilesFromPath(dirpath)
+	if err != nil {
+		return nil, fmt.Errorf("getDashboardFilesFromPath err: %w", err)
+	}
+
 	var dashboards []model.Dashboard
 	for _, filename := range files {
 		dashboard, err := loadDashboardFromFile(filename)

--- a/pkg/store/dashboard/dashboard.go
+++ b/pkg/store/dashboard/dashboard.go
@@ -57,7 +57,7 @@ func loadDashboardFromFile(filename string) (*model.Dashboard, error) {
 	yamlBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("error on ReadFile: %w", err)
-	}
+	} 
 	var dashboard *model.Dashboard
 	if err := yaml.UnmarshalStrict(yamlBytes, &dashboard); err != nil {
 		return nil, fmt.Errorf("error on UnmarshalStrict: %w", err)

--- a/pkg/store/dashboard/dashboard.go
+++ b/pkg/store/dashboard/dashboard.go
@@ -57,7 +57,7 @@ func loadDashboardFromFile(filename string) (*model.Dashboard, error) {
 	yamlBytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("error on ReadFile: %w", err)
-	} 
+	}
 	var dashboard *model.Dashboard
 	if err := yaml.UnmarshalStrict(yamlBytes, &dashboard); err != nil {
 		return nil, fmt.Errorf("error on UnmarshalStrict: %w", err)

--- a/pkg/store/dashboard/dashboard_test.go
+++ b/pkg/store/dashboard/dashboard_test.go
@@ -51,7 +51,7 @@ func init() {
 			{Title: "event", Type: "logs", Headers: []string(nil), Targets: []model.Target{{Expr: "pod{namespace=\"kube-system\",pod=\"eventrouter-.*\"}", Legend: "", Legends: []string(nil), Unit: "", Columns: []string(nil), Headers: []string(nil), Key: "", Thresholds: []model.Threshold(nil)}}, ChartOptions: (*model.ChartOptions)(nil)}}}}}
 
 	var err error
-	store1, err = New("etc/dashboards/*.yml")
+	store1, err = New("etc/dashboards")
 	if err != nil {
 		panic(err)
 	}
@@ -69,12 +69,12 @@ func TestNew(t *testing.T) {
 			"",
 		},
 		{
-			"etc/dashboards/*.yaml",
+			"etc/hello",
 			nil,
-			"no dashboard file: pattern: etc/dashboards/*.yaml",
+			"getDashboardFilesFromPath err: no dashboard file: dirpath: etc/hello",
 		},
 		{
-			"etc/dashboards/*.yml",
+			"etc/dashboards",
 			&DashboardStore{dashboards: []model.Dashboard{*sampleDashboard}},
 			"",
 		},

--- a/pkg/store/dashboard/dashboard_test.go
+++ b/pkg/store/dashboard/dashboard_test.go
@@ -59,7 +59,7 @@ func init() {
 
 func TestNew(t *testing.T) {
 	testCases := []struct {
-		pattern   string
+		dirpath   string
 		want      *DashboardStore
 		wantError string
 	}{
@@ -81,7 +81,7 @@ func TestNew(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
-			store, err := New(tc.pattern)
+			store, err := New(tc.dirpath)
 			if tc.wantError == "" {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -36,7 +36,7 @@ func NewStores(cfg *model.Config) (*Stores, error) {
 
 	// dashboard
 	logger.Debugf("new dashboard store...")
-	dashboardStore, err := dashboard.New("etc/dashboards/*.yml")
+	dashboardStore, err := dashboard.New("etc/dashboards")
 	if err != nil {
 		return nil, fmt.Errorf("NewDashboardStore err: %w", err)
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -42,7 +42,6 @@ func NewStores(cfg *model.Config) (*Stores, error) {
 	}
 
 	// datasource
-	logger.Infof("hello 1")
 	var discoverer discovery.Discoverer
 	if cfg.DatasourceConfig.Discovery.Enabled {
 		discoverer, err = kubernetes.NewK8sStore()


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

loadDashboardFromFile 오류 해결

dashboard yaml 파일 하위 디렉토리 읽기

현재 glob 패턴 방식으로는 etc/dashboards/*.y*ml 으로는
etc/dashboards/common/aaa.yml
etc/dashboards/user/bbb.yml
와 같은 경로에 있는 파일을 로드할 수 없습니다.

또한 glob 패턴에 **을 사용할 수 없어서 `etc/dashboards/**/.y*ml`로 해도 안됩니다.
그래서 디렉토리 경로를 받아서 해당 디렉토리와 하위 디렉토리에서 yaml 파일을 로드하도록 수정하였습니다.

 
예전에 Unmarshal을 UnmarshalStrict로 바꾼 영향으로
기존 설정 일부를 읽지 못하는 현상이 있었는데 해결하였습니다.


#### Which issue(s) this PR fixes (관련 이슈):

- #66 
- #68 

#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다.


#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

recursive(**) 불가 https://github.com/golang/go/issues/11862

