### PR TITLE
multitable + alert(commonLabels) bugfix

### DIFF
--- a/pkg/alerter/alerter_test.go
+++ b/pkg/alerter/alerter_test.go
@@ -175,7 +175,8 @@ func TestProcessRuleAlert(t *testing.T) {
 		// ok
 		{
 			&model.RuleAlert{Rule: model.Rule{Alert: "alert1", Expr: "up"}, Alerts: []model.Alert{{Datasource: datasource5}}},
-			[]model.Fire{{Labels: map[string]string{"alertname": "alert1", "firer": "venti"}, Annotations: map[string]string{"summary": "placeholder summary"}}},
+			[]model.Fire{
+				{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "severity": "info"}, Annotations: map[string]string{"summary": "placeholder summary"}}},
 		},
 		// error
 		{
@@ -185,7 +186,7 @@ func TestProcessRuleAlert(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
-			got := alerter1.processRuleAlert(tc.ruleAlert)
+			got := alerter1.processRuleAlert(tc.ruleAlert, &map[string]string{"severity": "info"})
 			require.Equal(t, tc.want, got)
 		})
 	}
@@ -273,9 +274,8 @@ func TestEvaluateAlert(t *testing.T) {
 			&model.Rule{},
 			&model.Alert{},
 			[]model.Fire{
-				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti"}, Annotations: map[string]string{"summary": "placeholder summary"}},
-				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti"}, Annotations: map[string]string{"summary": "placeholder summary"}},
-			},
+				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti", "severity": "info"}, Annotations: map[string]string{"summary": "placeholder summary"}},
+				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti", "severity": "info"}, Annotations: map[string]string{"summary": "placeholder summary"}}},
 		},
 		// pending
 		{
@@ -287,7 +287,7 @@ func TestEvaluateAlert(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("#%d", i), func(tt *testing.T) {
-			fires := evaluateAlert(tc.queryData, tc.rule, tc.alert)
+			fires := evaluateAlert(tc.queryData, tc.rule, tc.alert, &map[string]string{"severity": "info"})
 			require.Equal(tt, tc.want, fires)
 		})
 	}
@@ -302,8 +302,7 @@ func TestGetFires_zero_QueryData(t *testing.T) {
 		{
 			&model.Rule{},
 			[]model.Fire{
-				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti"}, Annotations: map[string]string{"summary": "placeholder summary"}},
-			},
+				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti", "severity": "info"}, Annotations: map[string]string{"summary": "placeholder summary"}}},
 		},
 		{
 			&model.Rule{
@@ -311,8 +310,7 @@ func TestGetFires_zero_QueryData(t *testing.T) {
 				Labels:      map[string]string{"lorem": "ipsum"},
 			},
 			[]model.Fire{
-				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti", "lorem": "ipsum"}, Annotations: map[string]string{"hello": "world", "summary": "placeholder summary"}},
-			},
+				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti", "lorem": "ipsum", "severity": "info"}, Annotations: map[string]string{"hello": "world", "summary": "placeholder summary"}}},
 		},
 		{
 			&model.Rule{
@@ -321,8 +319,7 @@ func TestGetFires_zero_QueryData(t *testing.T) {
 				Labels:      map[string]string{"lorem": "ipsum"},
 			},
 			[]model.Fire{
-				{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "lorem": "ipsum"}, Annotations: map[string]string{"hello": "world", "summary": "lorem={{ $labels.lorem }} value={{ $value }}"}},
-			},
+				{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "lorem": "ipsum", "severity": "info"}, Annotations: map[string]string{"hello": "world", "summary": "lorem={{ $labels.lorem }} value={{ $value }}"}}},
 		},
 		{
 			&model.Rule{
@@ -331,13 +328,12 @@ func TestGetFires_zero_QueryData(t *testing.T) {
 				Labels:      map[string]string{"lorem": "ipsum"},
 			},
 			[]model.Fire{
-				{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "lorem": "ipsum"}, Annotations: map[string]string{"hello": "world", "summary": "lorem={{ $labels.lorem }} value={{}}"}},
-			},
+				{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "lorem": "ipsum", "severity": "info"}, Annotations: map[string]string{"hello": "world", "summary": "lorem={{ $labels.lorem }} value={{}}"}}},
 		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("#%d", i), func(tt *testing.T) {
-			fires := getFires(tc.rule, queryData)
+			fires := getFires(tc.rule, queryData, &map[string]string{"severity": "info"})
 			require.Equal(tt, tc.want, fires)
 		})
 	}
@@ -364,7 +360,7 @@ func TestGetFires_vector_zero_Result(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("#%d", i), func(tt *testing.T) {
-			fires := getFires(tc.rule, queryData)
+			fires := getFires(tc.rule, queryData, &map[string]string{"severity": "info"})
 			require.Equal(tt, tc.want, fires)
 		})
 	}
@@ -392,9 +388,7 @@ func TestGetFires_vector_two_Result(t *testing.T) {
 		{
 			&model.Rule{},
 			[]model.Fire{
-				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti"}, Annotations: map[string]string{"summary": "placeholder summary"}},
-				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti"}, Annotations: map[string]string{"summary": "placeholder summary"}},
-			},
+				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti", "severity": "info"}, Annotations: map[string]string{"summary": "placeholder summary"}}, model.Fire{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti", "severity": "info"}, Annotations: map[string]string{"summary": "placeholder summary"}}},
 		},
 		{
 			&model.Rule{
@@ -402,9 +396,7 @@ func TestGetFires_vector_two_Result(t *testing.T) {
 				Labels:      map[string]string{"lorem": "ipsum"},
 			},
 			[]model.Fire{
-				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti", "lorem": "ipsum"}, Annotations: map[string]string{"hello": "world", "summary": "placeholder summary"}},
-				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti", "lorem": "ipsum"}, Annotations: map[string]string{"hello": "world", "summary": "placeholder summary"}},
-			},
+				{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti", "lorem": "ipsum", "severity": "info"}, Annotations: map[string]string{"hello": "world", "summary": "placeholder summary"}}, model.Fire{Labels: map[string]string{"alertname": "placeholder name", "firer": "venti", "lorem": "ipsum", "severity": "info"}, Annotations: map[string]string{"hello": "world", "summary": "placeholder summary"}}},
 		},
 		{
 			&model.Rule{
@@ -413,9 +405,7 @@ func TestGetFires_vector_two_Result(t *testing.T) {
 				Labels:      map[string]string{"rule": "pod-v1"},
 			},
 			[]model.Fire{
-				{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "rule": "pod-v1"}, Annotations: map[string]string{"summary": "pod=pod1 value=1111"}},
-				{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "rule": "pod-v1"}, Annotations: map[string]string{"summary": "pod=pod2 value=2222"}},
-			},
+				{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "rule": "pod-v1", "severity": "info"}, Annotations: map[string]string{"summary": "pod=pod1 value=1111"}}, model.Fire{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "rule": "pod-v1", "severity": "info"}, Annotations: map[string]string{"summary": "pod=pod2 value=2222"}}},
 		},
 		{
 			&model.Rule{
@@ -424,14 +414,12 @@ func TestGetFires_vector_two_Result(t *testing.T) {
 				Labels:      map[string]string{"rule": "pod-v1"},
 			},
 			[]model.Fire{
-				{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "rule": "pod-v1"}, Annotations: map[string]string{"summary": "pod={{ $labels.pod }} value={{}}"}},
-				{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "rule": "pod-v1"}, Annotations: map[string]string{"summary": "pod={{ $labels.pod }} value={{}}"}},
-			},
+				{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "rule": "pod-v1", "severity": "info"}, Annotations: map[string]string{"summary": "pod={{ $labels.pod }} value={{}}"}}, model.Fire{Labels: map[string]string{"alertname": "alert1", "firer": "venti", "rule": "pod-v1", "severity": "info"}, Annotations: map[string]string{"summary": "pod={{ $labels.pod }} value={{}}"}}},
 		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("#%d", i), func(tt *testing.T) {
-			fires := getFires(tc.rule, queryData)
+			fires := getFires(tc.rule, queryData, &map[string]string{"severity": "info"})
 			require.Equal(tt, tc.want, fires)
 		})
 	}
@@ -516,11 +504,14 @@ func TestRenderSummary_error_on_Parse(t *testing.T) {
 		},
 	}
 	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("#%d", i), func(tt *testing.T) {
+		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
 			output, err := renderSummary(tc.input, tc.sample)
-			require.NotNil(tt, err)
-			require.Error(tt, err, tc.wantError)
-			require.Equal(tt, tc.input, output)
+			if tc.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.wantError)
+			}
+			require.Equal(t, tc.input, output)
 		})
 	}
 }
@@ -534,12 +525,12 @@ func TestRenderSummary_error_on_Execute(t *testing.T) {
 		{
 			"AlwaysOn value={{}",
 			&commonModel.Sample{},
-			`error on Parse: template: :1: missing value for command`,
+			`error on Parse: template: :1: unexpected "}" in command`,
 		},
 		{
 			"AlwaysOn value={{ }",
 			&commonModel.Sample{},
-			`error on Parse: template: :1: missing value for command`,
+			`error on Parse: template: :1: unexpected "}" in command`,
 		},
 		{
 			"AlwaysOn value={{ }}",
@@ -558,11 +549,14 @@ func TestRenderSummary_error_on_Execute(t *testing.T) {
 		},
 	}
 	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("#%d", i), func(tt *testing.T) {
-			output, err := renderSummary(tc.input, tc.sample)
-			require.NotNil(tt, err)
-			require.Error(tt, err, tc.wantError)
-			require.Equal(tt, tc.input, output)
+		t.Run(fmt.Sprintf("#%d", i), func(t *testing.T) {
+			got, err := renderSummary(tc.input, tc.sample)
+			if tc.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.wantError)
+			}
+			require.Equal(t, tc.input, got)
 		})
 	}
 }
@@ -574,7 +568,7 @@ func TestSendFires_ok(t *testing.T) {
 			Annotations: map[string]string{"lorem": "ipsum"},
 		},
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestSendFires_error_on_Post(t *testing.T) {

--- a/web/src/components/PanelMultitable.vue
+++ b/web/src/components/PanelMultitable.vue
@@ -37,10 +37,10 @@ export default {
     },
   },
   mounted() {
-    this.init();
+    this.fetchDatasources();
   },
   methods: {
-    async init() {
+    async fetchDatasources() {
       try {
         const response = await fetch('/api/v1/datasources');
         const jsonData = await response.json();
@@ -55,13 +55,15 @@ export default {
       this.$emit('setIsLoading', true);
       try {
         let rows = [];
-        this.datasources.forEach((ds, dsid) => {
-          if (ds.type != 'prometheus' || !ds.isDiscovered) {
-            return
-          }
+        for (let i = 0; i < this.datasources.length; i++) {
+          const ds = this.datasources[i];
+          if (ds.type != 'prometheus' || !ds.isDiscovered) continue;
+
           let row = [];
           for (const target of this.panelConfig.targets) {
-            const response = await fetch('/api/v1/remote/query?' + new URLSearchParams({ dsid: dsid, query: target.expr, time: this.timeRange[1] }));
+            const response = await fetch(
+              '/api/v1/remote/query?' + new URLSearchParams({ dsid: i, query: target.expr, time: this.timeRange[1] }),
+            );
             const jsonData = await response.json();
             const result = jsonData.data.result;
             if (!target.legends) {
@@ -74,7 +76,7 @@ export default {
             }
           }
           rows.push(row);
-        })
+        }
         this.rows = rows;
       } catch (error) {
         console.error(error);

--- a/web/src/components/PanelTable.vue
+++ b/web/src/components/PanelTable.vue
@@ -34,8 +34,10 @@ export default {
         try {
           const target = targets[i];
 
-
-          const response = await fetch('/api/v1/remote/query?' + new URLSearchParams({ dstype: 'prometheus', query: target.expr, time: this.timeRange[1] }));
+          const response = await fetch(
+            '/api/v1/remote/query?' +
+              new URLSearchParams({ dstype: 'prometheus', query: target.expr, time: this.timeRange[1] }),
+          );
           const jsonData = await response.json();
           let rows = {};
           jsonData.data.result.forEach(x => {

--- a/web/src/components/PanelTable.vue
+++ b/web/src/components/PanelTable.vue
@@ -33,14 +33,12 @@ export default {
       for (const i in targets) {
         try {
           const target = targets[i];
-          const response = await this.axios.get('/api/prometheus/query', {
-            params: {
-              expr: target.expr,
-              time: this.timeRange[1],
-            },
-          });
+
+
+          const response = await fetch('/api/v1/remote/query?' + new URLSearchParams({ dstype: 'prometheus', query: target.expr, time: this.timeRange[1] }));
+          const jsonData = await response.json();
           let rows = {};
-          response.data.data.result.forEach(x => {
+          jsonData.data.result.forEach(x => {
             const key = x.metric[target.key];
             let row = {};
             target.columns.forEach(c => {


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

[frontend]
API 변경 이후로 multitable(여러 데이터소스 조회결과 집계 표) 패널이 제대로 작동하지 않고 있었던 것을 바로 잡았습니다. 프론트엔드는 아직 테스트코드 체계가 없어서 배포 후 점검하여 이상없음을 확인하였습니다.

[backend]
commonLabels이 fire.labels에 전달되지 않아서 alertmanager에서 severity 레이블이 누락되었고 그에 따라 alert이 발송되지 않던 문제를 바로 잡았습니다. 테스트 코드에도 commonLabels 추가하였습니다. 단위 테스트 및 개발서버 테스트에서 이상없음을 확인하였습니다.


#### Which issue(s) this PR fixes (관련 이슈):

- #70 
- #71 


#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다~!

별로 바꾼 것도 없는데 테스트 코드가 있으니까 사이즈 L로 나오네요 ㅎ

#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

- [TMI] commonLabels에 관한 아이디어는 kustomize에서 참고하였습니다. https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#kustomize-feature-list
