### PR TITLE
Add token middleware

### DIFF
--- a/pkg/handler/middleware.go
+++ b/pkg/handler/middleware.go
@@ -2,10 +2,10 @@ package handler
 
 import (
 	"fmt"
-	"github.com/kuoss/venti/pkg/handler/api"
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/kuoss/venti/pkg/handler/api"
 )
 
 func tokenRequired() gin.HandlerFunc {

--- a/pkg/handler/middleware.go
+++ b/pkg/handler/middleware.go
@@ -1,0 +1,36 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func tokenRequired() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		token := c.GetHeader("Authorization")
+		if token == "" || !strings.HasPrefix(token, "Bearer ") {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"message": "valid token required",
+			})
+			return
+		}
+		at := strings.Split(token, " ")
+		if len(at) != 2 {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"message": "valid token required",
+			})
+			return
+		}
+		token = at[1]
+		// fixme: decide token
+		if token != "fixme" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"message": "valid token required",
+			})
+			return
+		}
+		c.Next()
+	}
+}

--- a/pkg/handler/middleware.go
+++ b/pkg/handler/middleware.go
@@ -1,7 +1,8 @@
 package handler
 
 import (
-	"net/http"
+	"fmt"
+	"github.com/kuoss/venti/pkg/handler/api"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -11,25 +12,19 @@ func tokenRequired() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		token := c.GetHeader("Authorization")
 		if token == "" || !strings.HasPrefix(token, "Bearer ") {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"message": "valid token required",
-			})
-			return
+			api.ResponseError(c, api.ErrorUnauthorized, fmt.Errorf("token required"))
+			c.Abort()
 		}
 		at := strings.Split(token, " ")
 		if len(at) != 2 {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"message": "valid token required",
-			})
-			return
+			api.ResponseError(c, api.ErrorUnauthorized, fmt.Errorf("valid token required"))
+			c.Abort()
 		}
 		token = at[1]
 		// fixme: decide token
 		if token != "fixme" {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"message": "valid token required",
-			})
-			return
+			api.ResponseError(c, api.ErrorUnauthorized, fmt.Errorf("valid token required"))
+			c.Abort()
 		}
 		c.Next()
 	}

--- a/pkg/handler/middleware_test.go
+++ b/pkg/handler/middleware_test.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInValidToken(t *testing.T) {
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.GET("/test", tokenRequired(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"message": "test",
+		})
+	})
+
+	w := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer INVALID")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Equal(t, "{\"message\":\"valid token required\"}", w.Body.String())
+}
+
+func TestValidToken(t *testing.T) {
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.GET("/test", tokenRequired(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"message": "test",
+		})
+	})
+
+	w := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "/test", nil)
+
+	req.Header.Set("Authorization", "Bearer fixme")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "{\"message\":\"test\"}", w.Body.String())
+}

--- a/pkg/handler/middleware_test.go
+++ b/pkg/handler/middleware_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInValidToken(t *testing.T) {
+func TestInvalidToken(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -26,7 +26,7 @@ func TestInValidToken(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Equal(t, "{\"message\":\"valid token required\"}", w.Body.String())
+	assert.Equal(t, "{\"error\":\"valid token required\",\"errorType\":\"unauthorized\",\"status\":\"error\"}", w.Body.String())
 }
 
 func TestValidToken(t *testing.T) {

--- a/pkg/handler/router.go
+++ b/pkg/handler/router.go
@@ -13,7 +13,7 @@ func NewRouter(cfg *model.Config, services *service.Services) *gin.Engine {
 	handlers := loadHandlers(cfg, services)
 
 	api := router.Group("/api/v1")
-	// TODO: api.Use(tokenRequired)
+	// fixme: api.Use(tokenRequired)
 	{
 		api.GET("/alerts", handlers.alertHandler.AlertRuleFiles)
 		api.GET("/config/version", handlers.configHandler.Version)

--- a/pkg/handler/router.go
+++ b/pkg/handler/router.go
@@ -13,7 +13,7 @@ func NewRouter(cfg *model.Config, services *service.Services) *gin.Engine {
 	handlers := loadHandlers(cfg, services)
 
 	api := router.Group("/api/v1")
-	// fixme: api.Use(tokenRequired)
+	// fixme: api.Use(tokenRequired())
 	{
 		api.GET("/alerts", handlers.alertHandler.AlertRuleFiles)
 		api.GET("/config/version", handlers.configHandler.Version)


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 
venti api 는 적절한 Bearer token 검증이 필요합니다. `router.go`에 정의되어있는 핸들러들 중 `/auth`와 헬스체크(`/-/healthy`,`/-/ready`)를 제외한 모든 api에 적용해야합니다.




#### Which issue(s) this PR fixes (관련 이슈):

#78 


#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

현재는 구현과 테스트 코드만 작성하였고, `route.go` 파일에 사용할 곳 마킹만 해두었습니다. 적절한 토큰 방식을 논의하면 좋을 것 같습니다.

#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

