### PR TITLE
optional channing for severity

### DIFF
--- a/web/src/views/AlertView.vue
+++ b/web/src/views/AlertView.vue
@@ -83,13 +83,13 @@ export default {
                 </span>
               </td>
               <td class="px-2">
-                {{ f.commonLabels.severity }}
+                {{ f.commonLabels?.severity }}
               </td>
               <td class="px-2">
                 {{ ra.rule.alert }}
               </td>
               <td class="px-2 max-w-[30vw] truncate hover:whitespace-normal">
-                {{ ra.rule.annotations.summary }}
+                {{ ra.rule.annotations?.summary }}
               </td>
               <td class="px-2 max-w-[20vw] truncate hover:whitespace-normal text-cyan-500">
                 <a


### PR DESCRIPTION
commonLabels에 severity가 없는 경우 Alert화면이 제대로 안나오는데,
없어도 화면이 제대로 나오도록 하였습니다. (optional chaining)

하는 김에 annotations에 summary가 없는 경우도 견딜(?) 수 있도록 동일한 방식으로 추가했습니다.