### PR TITLE
send test alert

### DIFF
--- a/pkg/handler/alert.go
+++ b/pkg/handler/alert.go
@@ -16,3 +16,11 @@ func NewAlertHandler(s *alerting.AlertingService) *alertHandler {
 func (h *alertHandler) AlertRuleFiles(c *gin.Context) {
 	c.JSON(200, h.alertingService.AlertFiles)
 }
+
+func (h *alertHandler) SendTestAlert(c *gin.Context) {
+	err := h.alertingService.SendTestAlert()
+	if err != nil {
+		c.JSON(500, gin.H{"status": "error", "error": err.Error()})
+	}
+	c.JSON(200, gin.H{"status": "success"})
+}

--- a/pkg/handler/alert_test.go
+++ b/pkg/handler/alert_test.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAlertHandler(t *testing.T) {
+	require.NotEmpty(t, handlers.alertHandler)
+}
+
+func TestAlertRuleFiles(t *testing.T) {
+	alertHandler1 := handlers.alertHandler
+	r := gin.Default()
+	r.GET("/", alertHandler1.AlertRuleFiles)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+	require.Equal(t, 200, w.Code)
+	want := `[{"commonLabels":{"rulefile":"sample-v3","severity":"silence"},"datasourceSelector":{"system":"","type":"prometheus"},"groups":[{"name":"sample","ruleAlerts":[{"rule":{"alert":"S00-AlwaysOn","expr":"vector(1234)","for":"0s","labels":{"hello":"world"},"annotations":{"summary":"AlwaysOn value={{ $value }}"}},"alerts":[{"datasource":{"type":"prometheus","name":"prometheus","url":"","basicAuth":false,"basicAuthUser":"","basicAuthPassword":"","isMain":true},"state":0,"activeAt":0}]},{"rule":{"alert":"S01-Monday","expr":"day_of_week() == 1 and hour() \u003c 2","for":"0s","annotations":{"summary":"Monday"}},"alerts":[{"datasource":{"type":"prometheus","name":"prometheus","url":"","basicAuth":false,"basicAuthUser":"","basicAuthPassword":"","isMain":true},"state":0,"activeAt":0}]},{"rule":{"alert":"S02-NewNamespace","expr":"time() - kube_namespace_created \u003c 120","for":"0s","annotations":{"summary":"labels={{ $labels }} namespace={{ $labels.namespace }} value={{ $value }}"}},"alerts":[{"datasource":{"type":"prometheus","name":"prometheus","url":"","basicAuth":false,"basicAuthUser":"","basicAuthPassword":"","isMain":true},"state":0,"activeAt":0}]}]}]}]`
+	require.Equal(t, want, w.Body.String())
+}
+
+func TestSendTestAlert(t *testing.T) {
+	alertHandler1 := handlers.alertHandler
+	r := gin.Default()
+	r.GET("/", alertHandler1.SendTestAlert)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+	require.Equal(t, 200, w.Code)
+	want := `{"status":"success"}`
+	require.Equal(t, want, w.Body.String())
+}

--- a/pkg/handler/init_test.go
+++ b/pkg/handler/init_test.go
@@ -53,12 +53,6 @@ func setup() {
 		panic(err)
 	}
 	services.AlertingService.AlertingFile.Alertings[0].URL = alertmanagerMock.URL
-	// var datasourceService *datasource.DatasourceService
-	// alertingService := alerting.New("etc/alerting.yml", []model.RuleFile{}, datasourceService)
-	// alertingService.AlertingFile.Alertings = []model.Alerting{
-	// 	{URL: alertmanagerMock.URL},
-	// }
-
 	handlers = loadHandlers(cfg, services)
 }
 

--- a/pkg/handler/init_test.go
+++ b/pkg/handler/init_test.go
@@ -3,10 +3,43 @@ package handler
 import (
 	"fmt"
 	"os"
+	"testing"
+
+	"github.com/kuoss/venti/pkg/mocker"
+	"github.com/kuoss/venti/pkg/mocker/alertmanager"
+	"github.com/kuoss/venti/pkg/model"
+	"github.com/kuoss/venti/pkg/service"
 )
 
-func init() {
-	err := os.Chdir("../..")
+var (
+	services         *service.Services
+	handlers         *Handlers
+	alertmanagerMock *mocker.Server
+	cfg              = &model.Config{
+		Version:    "Unknown",
+		UserConfig: model.UserConfig{},
+		DatasourceConfig: model.DatasourceConfig{
+			Datasources: []model.Datasource{
+				{Type: model.DatasourceTypePrometheus, Name: "prometheus", IsMain: true},
+			},
+		},
+	}
+)
+
+func TestMain(m *testing.M) {
+	setup()
+	code := m.Run()
+	shutdown()
+	os.Exit(code)
+}
+
+func setup() {
+	var err error
+	alertmanagerMock, err = alertmanager.New(0)
+	if err != nil {
+		panic(err)
+	}
+	err = os.Chdir("../..")
 	if err != nil {
 		panic(err)
 	}
@@ -15,4 +48,20 @@ func init() {
 		panic(err)
 	}
 	fmt.Println("working directory:", wd)
+	services, err = service.NewServices(cfg)
+	if err != nil {
+		panic(err)
+	}
+	services.AlertingService.AlertingFile.Alertings[0].URL = alertmanagerMock.URL
+	// var datasourceService *datasource.DatasourceService
+	// alertingService := alerting.New("etc/alerting.yml", []model.RuleFile{}, datasourceService)
+	// alertingService.AlertingFile.Alertings = []model.Alerting{
+	// 	{URL: alertmanagerMock.URL},
+	// }
+
+	handlers = loadHandlers(cfg, services)
+}
+
+func shutdown() {
+	alertmanagerMock.Close()
 }

--- a/pkg/handler/init_test.go
+++ b/pkg/handler/init_test.go
@@ -39,7 +39,7 @@ func setup() {
 	if err != nil {
 		panic(err)
 	}
-	err = os.Chdir("../..")
+	err = os.Chdir("../..") // project root
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/handler/router.go
+++ b/pkg/handler/router.go
@@ -16,6 +16,7 @@ func NewRouter(cfg *model.Config, services *service.Services) *gin.Engine {
 	// fixme: api.Use(tokenRequired())
 	{
 		api.GET("/alerts", handlers.alertHandler.AlertRuleFiles)
+		api.GET("/alerts/test", handlers.alertHandler.SendTestAlert)
 		api.GET("/config/version", handlers.configHandler.Version)
 		api.GET("/dashboards", handlers.dashboardHandler.Dashboards)
 

--- a/pkg/handler/router_test.go
+++ b/pkg/handler/router_test.go
@@ -3,25 +3,10 @@ package handler
 import (
 	"testing"
 
-	"github.com/kuoss/venti/pkg/model"
-	"github.com/kuoss/venti/pkg/service"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSetupRouter(t *testing.T) {
-	cfg := &model.Config{
-		Version:    "Unknown",
-		UserConfig: model.UserConfig{},
-		DatasourceConfig: model.DatasourceConfig{
-			Datasources: []model.Datasource{
-				{Type: model.DatasourceTypePrometheus, Name: "prometheus", IsMain: true},
-			},
-		},
-	}
-	services, err := service.NewServices(cfg)
-	assert.NoError(t, err)
-
-	handlers := loadHandlers(cfg, services)
 	assert.NotEmpty(t, handlers)
 	assert.NotEmpty(t, handlers.alertHandler)
 	assert.NotEmpty(t, handlers.authHandler)

--- a/pkg/service/alerting/alerting.go
+++ b/pkg/service/alerting/alerting.go
@@ -87,7 +87,7 @@ func (s *AlertingService) GetAlertmanagerURL() string {
 
 func (s *AlertingService) SendTestAlert() error {
 	fires := []model.Fire{
-		{Labels: map[string]string{"test": "alert", "alert": "test"}},
+		{Labels: map[string]string{"test": "alert", "alert": "test", "pizza": "🍕"}},
 	}
 	pbytes, err := json.Marshal(fires)
 	if err != nil {

--- a/pkg/service/alerting/alerting.go
+++ b/pkg/service/alerting/alerting.go
@@ -1,8 +1,12 @@
 package alerting
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/kuoss/common/logger"
 	"github.com/kuoss/venti/pkg/model"
@@ -79,4 +83,28 @@ func (s *AlertingService) GetAlertmanagerURL() string {
 		return s.AlertingFile.Alertings[0].URL
 	}
 	return ""
+}
+
+func (s *AlertingService) SendTestAlert() error {
+	fires := []model.Fire{
+		{Labels: map[string]string{"test": "alert", "alert": "test"}},
+	}
+	pbytes, err := json.Marshal(fires)
+	if err != nil {
+		// test not reachable: memory full?
+		return fmt.Errorf("error on Marshal: %w", err)
+	}
+	buff := bytes.NewBuffer(pbytes)
+	client := http.Client{
+		Timeout: 5 * time.Second,
+	}
+	resp, err := client.Post(s.GetAlertmanagerURL()+"/api/v1/alerts", "application/json", buff)
+	if err != nil {
+		return fmt.Errorf("error on Post: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("statusCode is not ok(200)")
+	}
+	return nil
 }

--- a/pkg/service/alerting/alerting_test.go
+++ b/pkg/service/alerting/alerting_test.go
@@ -42,7 +42,7 @@ func setup() {
 		panic(err)
 	}
 
-	err = os.Chdir("../../..")
+	err = os.Chdir("../../..") // project root
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/service/alerting/alerting_test.go
+++ b/pkg/service/alerting/alerting_test.go
@@ -197,5 +197,8 @@ func TestGetAlertmanagerURL(t *testing.T) {
 }
 
 func TestSendTestAlert(t *testing.T) {
-
+	service := New("etc/alerting.yml", ruleFiles, datasourceService)
+	service.AlertingFile.Alertings[0].URL = alertmanagerMock.URL
+	err := service.SendTestAlert()
+	require.NoError(t, err)
 }

--- a/pkg/service/alerting/alerting_test.go
+++ b/pkg/service/alerting/alerting_test.go
@@ -26,17 +26,6 @@ var (
 				{Record: "", Alert: "S01-Monday", Expr: "day_of_week() == 1 and hour() < 2", For: 0, KeepFiringFor: 0, Labels: map[string]string(nil), Annotations: map[string]string{"summary": "Monday"}},
 				{Record: "", Alert: "S02-NewNamespace", Expr: "time() - kube_namespace_created < 120", For: 0, KeepFiringFor: 0, Labels: map[string]string(nil), Annotations: map[string]string{"summary": "labels={{ $labels }} namespace={{ $labels.namespace }} value={{ $value }}"}},
 			}}}}}
-
-	// alertFiles1 = []model.AlertFile{{
-	// 	Kind:               "",
-	// 	CommonLabels:       map[string]string{"rulefile": "sample-v3", "severity": "silence"},
-	// 	DatasourceSelector: model.DatasourceSelector{System: "", Type: "prometheus"},
-	// 	AlertGroups: []model.AlertGroup{{
-	// 		Name: "sample", Interval: 0, Limit: 0,
-	// 		RuleAlerts: []model.RuleAlert{
-	// 			{Rule: model.Rule{Record: "", Alert: "S00-AlwaysOn", Expr: "vector(1234)", For: 0, KeepFiringFor: 0, Labels: map[string]string{"hello": "world"}, Annotations: map[string]string{"summary": "AlwaysOn value={{ $value }}"}}, Alerts: []model.Alert{}},
-	// 			{Rule: model.Rule{Record: "", Alert: "S01-Monday", Expr: "day_of_week() == 1 and hour() < 2", For: 0, KeepFiringFor: 0, Labels: map[string]string(nil), Annotations: map[string]string{"summary": "Monday"}}, Alerts: []model.Alert{}},
-	// 			{Rule: model.Rule{Record: "", Alert: "S02-NewNamespace", Expr: "time() - kube_namespace_created < 120", For: 0, KeepFiringFor: 0, Labels: map[string]string(nil), Annotations: map[string]string{"summary": "labels={{ $labels }} namespace={{ $labels.namespace }} value={{ $value }}"}}, Alerts: []model.Alert{}}}}}}}
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

venti -> alertmanager로 alert이 잘 전달되는지 확인하기 위해
kubectl create ns xxx, kubectl delete ns xxx 로 하고 있었는데,

delete ns는 실수하면 문제가 될 수 있으니...
간단한 테스트용 alert을 보내는 API가 있는 것이 좋겠다는 의견이 있었습니다.

service 패키지와 handler 패키지에 테스트 코드를 구현하였습니다.

#### Which issue(s) this PR fixes (관련 이슈):

- #77 


#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다.

#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

없음