### PR TITLE
refactor DatasourceService & discoverer test

### DIFF
--- a/pkg/service/datasource/datasource.go
+++ b/pkg/service/datasource/datasource.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kuoss/common/logger"
 	"github.com/kuoss/venti/pkg/model"
 	"github.com/kuoss/venti/pkg/service/discovery"
 )
@@ -35,14 +34,10 @@ func (s *DatasourceService) load() error {
 
 		discoveredDatasources, err := s.discoverer.Do(s.config.Discovery)
 		if err != nil {
-			logger.Errorf("error on discoverDatasources: %s", err)
+			return fmt.Errorf("discoverer.Do err: %w", err)
 		}
 		s.datasources = append(s.datasources, discoveredDatasources...)
 	}
-	// if len(s.datasources) < 1 {
-	// 	return fmt.Errorf("no datasource")
-	// }
-	// set main datasources
 	s.setMainDatasources()
 	return nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

기존에는 discoverer.Do()에서 error가 발생해도 로그 하나만 남겼는데, 상위로 전달하도록 바꿨습니다.
기능면에서도 이게 맞을 것 같습니다.
또한 기존에는 사실상 load()에서 error가 발생하지 않는 구조였습니다.

기존에는 discovery를 해보는 discovery: true에 대한 테스트가 없어서 추가했습니다.
이에 따라 New(), load()에서 에러핸들링 부분을 커버하게 되었습니다.

원래 discoverer는 k8s service를 참조하기 때문문에 단위테스트가 어려웠는데,
이번에 discoverer에 대한 mock 2가지를 추가하여 테스트가 가능해졌습니다.

discoverer가 정상작동하는 경우와 오류발생하는 경우를 테스트하기 위해
discovererOkMock과 discovererErrorMock을 추가하였습니다.

그리고, 근처의 불필요한 주석을 제거하였습니다.

#### Which issue(s) this PR fixes (관련 이슈):

- #91 


#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다.


#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

없음