### PR TITLE
AlertingRuleGroup

### DIFF
--- a/pkg/service/alerting/types.go
+++ b/pkg/service/alerting/types.go
@@ -38,11 +38,15 @@ type Alert struct {
 	Annotations map[string]string
 }
 
-type AlertingRule struct {
+type AlertingRuleGroup struct {
 	datasourceSelector model.DatasourceSelector
-	commonLabels       map[string]string
-	rule               model.Rule
-	active             map[uint64]*Alert
+	groupLabels        map[string]string
+	alertingRules      []AlertingRule
+}
+
+type AlertingRule struct {
+	rule   model.Rule
+	active map[uint64]*Alert
 }
 
 func (r AlertingRule) State() AlertState {

--- a/pkg/service/alerting/types_test.go
+++ b/pkg/service/alerting/types_test.go
@@ -1,0 +1,64 @@
+package alerting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertStateString(t *testing.T) {
+	testCases := []struct {
+		alertState AlertState
+		want       string
+		wantPanic  string
+	}{
+		{StateInactive, "inactive", ""},
+		{StatePending, "pending", ""},
+		{StateFiring, "firing", ""},
+		{-1, "", "unknown alert state: -1"},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			if tc.wantPanic == "" {
+				got := tc.alertState.String()
+				require.Equal(t, tc.want, got)
+			} else {
+				require.PanicsWithError(t, tc.wantPanic, func() {
+					got := tc.alertState.String()
+					require.Equal(t, "", got)
+				})
+			}
+		})
+	}
+}
+
+func TestAlertingRuleState(t *testing.T) {
+	testCases := []struct {
+		alerts map[uint64]*Alert
+		want   AlertState
+	}{
+		{
+			map[uint64]*Alert{},
+			StateInactive,
+		},
+		{
+			map[uint64]*Alert{0: {State: StateInactive}},
+			StateInactive,
+		},
+		{
+			map[uint64]*Alert{0: {State: StatePending}},
+			StatePending,
+		},
+		{
+			map[uint64]*Alert{0: {State: StateFiring}},
+			StateFiring,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			alertingRule := AlertingRule{active: tc.alerts}
+			got := alertingRule.State()
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

AlertingRule의 집합체 AlertingRuleGroup 도입했습니다.
기존에는 datasourceSelector가 AlertingRule에 있었는데 한 단계 위의 단위를 신설하여 효율화하였습니다.

fires를 return 받는 대신 포인터로 보내어 추가되게 하였습니다.

테스트 코드를 추가했습니다. (pkg/service/alerting 패키지 커버리지 95.1%)

#### Which issue(s) this PR fixes (관련 이슈):

- #116 


#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다


#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

없음

