### PR TITLE
evalalertingruledatasource-err-nil

### DIFF
--- a/pkg/service/alerting/alerting.go
+++ b/pkg/service/alerting/alerting.go
@@ -117,7 +117,9 @@ func (s *AlertingService) evalAlertingRule(ar *AlertingRule, datasources []model
 
 	for _, datasource := range datasources {
 		err := s.evalAlertingRuleDatasource(ar, datasource, labels, evalTime)
-		logger.Warnf("evalAlertingRuleDatasource err: %s", err)
+		if err != nil {
+			logger.Warnf("evalAlertingRuleDatasource err: %s", err)
+		}
 	}
 	for key, alert := range ar.active {
 		// remove old alerts


### PR DESCRIPTION
#### What this PR does / why we need it (변경 내용 / 필요성): 

err가 nil인 경우에도 로그를 남겨서 로그가 너무 많아집니다.

#### Which issue(s) this PR fixes (관련 이슈):

- #118 


#### Special notes for your reviewer (리뷰어에게 하고 싶은 말):

리뷰 감사합니다.

#### Additional documentation, usage docs, etc. (기타 관련 문서, 사용법 등):

없음