### PR TITLE
fix log alert bug, add log label 

### DIFF
--- a/pkg/service/alerting/alerting.go
+++ b/pkg/service/alerting/alerting.go
@@ -309,7 +309,18 @@ func getDataFromLogs(bodyBytes []byte) ([]commonmodel.Sample, error) {
 	if err != nil {
 		return []commonmodel.Sample{}, fmt.Errorf("unmarshal err: %w", err)
 	}
-	return []commonmodel.Sample{{Value: commonmodel.SampleValue(len(body.Data.Result))}}, nil
+
+	if len(body.Data.Result) == 0 {
+		return nil, nil
+	}
+
+	logData := commonmodel.Metric{}
+	logData["log"] = commonmodel.LabelValue(string(bodyBytes))
+
+	return []commonmodel.Sample{{
+		Metric: logData,
+		Value:  commonmodel.SampleValue(len(body.Data.Result)),
+	}}, nil
 }
 
 func getDataFromVector(bodyBytes []byte) ([]commonmodel.Sample, error) {

--- a/pkg/service/alerting/alerting.go
+++ b/pkg/service/alerting/alerting.go
@@ -311,12 +311,15 @@ func getDataFromLogs(bodyBytes []byte) ([]commonmodel.Sample, error) {
 	}
 
 	if len(body.Data.Result) == 0 {
-		return nil, nil
+		return []commonmodel.Sample{}, nil
 	}
 
-	logData := commonmodel.Metric{}
-	logData["log"] = commonmodel.LabelValue(string(bodyBytes))
-
+	var logData = make(map[commonmodel.LabelName]commonmodel.LabelValue)
+	for _, token := range body.Data.Result {
+		for k, v := range token {
+			logData[commonmodel.LabelName(k)] = commonmodel.LabelValue(v)
+		}
+	}
 	return []commonmodel.Sample{{
 		Metric: logData,
 		Value:  commonmodel.SampleValue(len(body.Data.Result)),

--- a/pkg/service/alerting/alerting_test.go
+++ b/pkg/service/alerting/alerting_test.go
@@ -188,8 +188,8 @@ func TestEvalAlertingRuleGroups(t *testing.T) {
 		{Labels: map[string]string{"__name__": "up", "alertname": "Up", "datasource": "prometheus2", "global1": "label1", "hello": "world", "instance2": "localhost:9092", "job": "prometheus2", "rulefile": "sample-v3", "severity": "silence"}, Annotations: map[string]string{"summary": "Up value=1"}},
 		{Labels: map[string]string{"__name__": "up", "alertname": "Up", "datasource": "prometheus3", "global1": "label1", "hello": "world", "instance": "localhost:9090", "job": "prometheus", "rulefile": "sample-v3", "severity": "silence"}, Annotations: map[string]string{"summary": "Up value=1"}},
 		{Labels: map[string]string{"__name__": "up", "alertname": "Up", "datasource": "prometheus3", "global1": "label1", "hello": "world", "instance2": "localhost:9092", "job": "prometheus2", "rulefile": "sample-v3", "severity": "silence"}, Annotations: map[string]string{"summary": "Up value=1"}},
-		{Labels: map[string]string{"alertname": "Pod", "datasource": "lethe1", "global1": "label1", "hello": "world", "rulefile": "sample-v3", "severity": "silence"}, Annotations: map[string]string{"summary": "PodLogs value=2"}},
-		{Labels: map[string]string{"alertname": "Pod", "datasource": "lethe2", "global1": "label1", "hello": "world", "rulefile": "sample-v3", "severity": "silence"}, Annotations: map[string]string{"summary": "PodLogs value=2"}}}
+		{Labels: map[string]string{"alertname": "Pod", "datasource": "lethe1", "global1": "label1", "hello": "world", "rulefile": "sample-v3", "severity": "silence", "time": "2009-11-10T22:59:00.000000Z", "namespace": "namespace01", "pod": "nginx-deployment-75675f5897-7ci7o", "container": "nginx", "log": "hello world"}, Annotations: map[string]string{"summary": "PodLogs value=2"}},
+		{Labels: map[string]string{"alertname": "Pod", "datasource": "lethe2", "global1": "label1", "hello": "world", "rulefile": "sample-v3", "severity": "silence", "time": "2009-11-10T22:59:00.000000Z", "namespace": "namespace01", "pod": "nginx-deployment-75675f5897-7ci7o", "container": "nginx", "log": "hello world"}, Annotations: map[string]string{"summary": "PodLogs value=2"}}}
 	require.ElementsMatch(t, fires, want)
 }
 
@@ -423,7 +423,7 @@ func TestQueryRule(t *testing.T) {
 		{
 			ruleFiles1[1].RuleGroups[0].Rules[0],
 			servers.GetDatasources()[1],
-			[]commonmodel.Sample{{Value: 2}},
+			[]commonmodel.Sample{{Metric: commonmodel.Metric{"container": "nginx", "log": "hello world", "namespace": "namespace01", "pod": "nginx-deployment-75675f5897-7ci7o", "time": "2009-11-10T22:59:00.000000Z"}, Value: 2}},
 			``,
 		},
 	}
@@ -446,14 +446,14 @@ func TestGetDataFromLogs(t *testing.T) {
 		want []commonmodel.Sample
 	}{
 		{
-			`{}`,
-			[]commonmodel.Sample{{Value: 0}},
+			`{"status":"success","data":{"resultType":"logs", "result":[]}}`,
+			[]commonmodel.Sample{},
 		},
 		{
 			`{"status":"success","data":{"resultType":"logs", "result":[
 				{"time":"2009-11-10T22:59:00.000000Z","namespace":"namespace01","pod":"nginx-deployment-75675f5897-7ci7o","container":"nginx","log":"lerom ipsum"},
 				{"time":"2009-11-10T22:59:00.000000Z","namespace":"namespace01","pod":"nginx-deployment-75675f5897-7ci7o","container":"nginx","log":"hello world"}]}}`,
-			[]commonmodel.Sample{{Value: 2}},
+			[]commonmodel.Sample{{Metric: commonmodel.Metric{"container": "nginx", "log": "hello world", "namespace": "namespace01", "pod": "nginx-deployment-75675f5897-7ci7o", "time": "2009-11-10T22:59:00.000000Z"}, Value: 2}},
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
when set log alert like pod{namespace="test"}|="error"
it fires even when it shouldn't fire
so, fix it to return nil when log is not exists
and set log label to Metric 
so we can use it like $labels.log when we get alert